### PR TITLE
Provide a sane set of hardened default values

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,61 @@
 # installed, or use `latest` to make sure the package is always at the latest
 # version.
 ssh_server_package_state: present
+
+ssh_server_allowgroups: []
+ssh_server_allowtcpforwarding: false
+ssh_server_allowusers: []
+ssh_server_banner: "/etc/issue.net"
+ssh_server_ciphers:
+  - "chacha20-poly1305@openssh.com"
+  - "aes256-gcm@openssh.com"
+  - "aes128-gcm@openssh.com"
+  - "aes256-ctr"
+  - "aes192-ctr"
+  - "aes128-ctr"
+
+ssh_server_clientalivecountmax: 0
+ssh_server_clientaliveinterval: 300
+ssh_server_denygroups: []
+ssh_server_denyusers: []
+ssh_server_hostbasedauthentication: false
+ssh_server_ignorerhosts: true
+
+ssh_server_kexalgorithms:
+  - "curve25519-sha256"
+  - "curve25519-sha256@libssh.org"
+  - "diffie-hellman-group14-sha256"
+  - "diffie-hellman-group16-sha512"
+  - "diffie-hellman-group18-sha512"
+  - "ecdh-sha2-nistp521"
+  - "ecdh-sha2-nistp384"
+  - "ecdh-sha2-nistp256"
+  - "diffie-hellman-group-exchange-sha256"
+
+ssh_server_logingracetime: 60
+
+# Logging level for SSH server.
+# Valid values are listed in the man pages for SSH config:
+# https://linux.die.net/man/5/ssh_config
+# http://manpages.ubuntu.com/manpages/trusty/en/man5/sshd_config.5.html
+ssh_server_loglevel: "verbose"
+
+ssh_server_macs:
+  - "hmac-sha2-512-etm@openssh.com"
+  - "hmac-sha2-256-etm@openssh.com"
+  - "hmac-sha2-512"
+  - "hmac-sha2-256"
+
+ssh_server_maxauthtries: 4
+ssh_server_maxsessions: 10
+ssh_server_maxstartups: "10:30:60"
+ssh_server_permitemptypasswords: false
+
+# Permit root user to login via SSH.
+# Valid values are true, false, "without-password", "prohibit-password",
+# and "forced-commands-only".
+ssh_server_permitrootlogin: false
+
+ssh_server_permituserenvironment: false
+ssh_server_usepam: true
+ssh_server_x11forwarding: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -10,3 +10,209 @@
       check_mode: true
       register: install
       failed_when: (install is changed) or (install is failed)
+
+    - name: Check permissions on sshd_config
+      file:
+        path: /etc/ssh/sshd_config
+        owner: root
+        group: root
+        mode: '0600'
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: Protocol defaults to 2"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "Protocol 2"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: LogLevel defaults to VERBOSE"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "LogLevel VERBOSE"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: X11Forwarding defaults to 'no'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "X11Forwarding no"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: MaxAuthTries defaults to 4"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "MaxAuthTries 4"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: IgnoreRhosts defaults to 'yes'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "IgnoreRhosts yes"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: HostbasedAuthentication defaults to 'no'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "HostbasedAuthentication no"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: PermitRootLogin defaults to 'no'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "PermitRootLogin no"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: PermitEmptyPasswords defaults to 'no'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "PermitEmptyPasswords no"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: PermitUserEnvironment defaults to 'no'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "PermitUserEnvironment no"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: Ciphers defaults to approved ciphers list"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: MACs defaults to approved MACs list"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: KexAlgorithms defaults to approved list"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: ClientAliveInterval defaults to 300"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "ClientAliveInterval 300"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: ClientAliveCountMax defaults to 0"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "ClientAliveCountMax 0"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: LoginGraceTime defaults to 60"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "LoginGraceTime 60"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: AllowUsers not present by default"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: "^AllowUsers.*$"
+        state: absent
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: AllowGroups not present by default"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: "^AllowGroups.*$"
+        state: absent
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: DenyUsers not present by default"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: "^DenyUsers.*$"
+        state: absent
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: DenyGroups not present by default"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "^DenyGroups.*$"
+        state: absent
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: Banner defaults to /etc/issue.net"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "Banner /etc/issue.net"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: UsePAM defaults to 'yes'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "UsePAM yes"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: AllowTcpForwarding defaults to 'no'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "AllowTcpForwarding no"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: MaxStartups defaults to '10:30:60'"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "MaxStartups 10:30:60"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)
+
+    - name: "SSH Config: MaxSessions defaults to 10"
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "MaxSessions 10"
+      check_mode: true
+      register: config
+      failed_when: (config is changed) or (config is failed)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- import_tasks: validate.yml
+  run_once: true
+  delegate_to: localhost
+
 - include_tasks: "variables.yml"
 - include_tasks: "install.yml"
 - include_tasks: "config.yml"

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,0 +1,160 @@
+- name: Verify ssh_server_allowgroups is set correctly
+  assert:
+    that:
+      - ssh_server_allowgroups is defined
+      - ssh_server_allowgroups is iterable
+    quiet: true
+
+- name: Verify ssh_server_allowtcpforwarding is set correctly
+  assert:
+    that:
+      - ssh_server_allowtcpforwarding is defined
+      - ssh_server_allowtcpforwarding is boolean
+    quiet: true
+
+- name: Verify ssh_server_allowusers is set correctly
+  assert:
+    that:
+      - ssh_server_allowusers is defined
+      - ssh_server_allowusers is iterable
+    quiet: true
+
+- name: Verify ssh_server_banner is set correctly
+  assert:
+    that:
+      - ssh_server_banner is defined
+      - ssh_server_banner is string
+    quiet: true
+
+- name: Verify ssh_server_ciphers is set correctly
+  assert:
+    that:
+      - ssh_server_ciphers is defined
+      - ssh_server_ciphers is iterable
+    quiet: true
+
+- name: Verify ssh_server_clientalivecountmax is set correctly
+  assert:
+    that:
+      - ssh_server_clientalivecountmax is defined
+      - ssh_server_clientalivecountmax is integer
+    quiet: true
+
+- name: Verify ssh_server_clientaliveinterval is set correctly
+  assert:
+    that:
+      - ssh_server_clientaliveinterval is defined
+      - ssh_server_clientaliveinterval is integer
+    quiet: true
+
+- name: Verify ssh_server_denygroups is set correctly
+  assert:
+    that:
+      - ssh_server_denygroups is defined
+      - ssh_server_denygroups is iterable
+    quiet: true
+
+- name: Verify ssh_server_denyusers is set correctly
+  assert:
+    that:
+      - ssh_server_denyusers is defined
+      - ssh_server_denyusers is iterable
+    quiet: true
+
+- name: Verify ssh_server_hostbasedauthentication is set correctly
+  assert:
+    that:
+      - ssh_server_hostbasedauthentication is defined
+      - ssh_server_hostbasedauthentication is boolean
+    quiet: true
+
+- name: Verify ssh_server_ignorerhosts is set correctly
+  assert:
+    that:
+      - ssh_server_ignorerhosts is defined
+      - ssh_server_ignorerhosts is boolean
+    quiet: true
+
+- name: Verify ssh_server_kexalgorithms is set correctly
+  assert:
+    that:
+      - ssh_server_kexalgorithms is defined
+      - ssh_server_kexalgorithms is iterable
+    quiet: true
+
+- name: Verify ssh_server_logingracetime is set correctly
+  assert:
+    that:
+      - ssh_server_logingracetime is defined
+      - ssh_server_logingracetime is integer
+    quiet: true
+
+- name: Verify ssh_server_loglevel is set correctly
+  assert:
+    that:
+      - ssh_server_loglevel is defined
+      - ssh_server_loglevel|lower is in ["quiet", "fatal", "error", "info", "verbose", "debug", "debug1", "debug2", "debug3"]
+    quiet: true
+
+- name: Verify ssh_server_macs is set correctly
+  assert:
+    that:
+      - ssh_server_macs is defined
+      - ssh_server_macs is iterable
+    quiet: true
+
+- name: Verify ssh_server_maxauthtries is set correctly
+  assert:
+    that:
+      - ssh_server_maxauthtries is defined
+      - ssh_server_maxauthtries is integer
+    quiet: true
+
+- name: Verify ssh_server_maxsessions is set correctly
+  assert:
+    that:
+      - ssh_server_maxsessions is defined
+      - ssh_server_maxsessions is integer
+    quiet: true
+
+- name: Verify ssh_server_maxstartups is set correctly
+  assert:
+    that:
+      - ssh_server_maxstartups is defined
+      - ssh_server_maxstartups is string
+    quiet: true
+
+- name: Verify ssh_server_permitemptypasswords is set correctly
+  assert:
+    that:
+      - ssh_server_permitemptypasswords is defined
+      - ssh_server_permitemptypasswords is boolean
+    quiet: true
+
+- name: Verify ssh_server_permitrootlogin is set correctly
+  assert:
+    that:
+      - ssh_server_permitrootlogin is defined
+      - ssh_server_permitrootlogin is in [true, false, "without-password", "prohibit-password", "forced-commands-only"]
+    quiet: true
+
+- name: Verify ssh_server_permituserenvironment is set correctly
+  assert:
+    that:
+      - ssh_server_permituserenvironment is defined
+      - ssh_server_permituserenvironment is boolean
+    quiet: true
+
+- name: Verify ssh_server_usepam is set correctly
+  assert:
+    that:
+      - ssh_server_usepam is defined
+      - ssh_server_usepam is boolean
+    quiet: true
+
+- name: Verify ssh_server_x11forwarding is set correctly
+  assert:
+    that:
+      - ssh_server_x11forwarding is defined
+      - ssh_server_x11forwarding is boolean
+    quiet: true

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -10,6 +10,8 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
+Protocol 2
+
 #Port 22
 #AddressFamily any
 #ListenAddress 0.0.0.0
@@ -21,18 +23,25 @@
 
 # Ciphers and keying
 #RekeyLimit default none
+Ciphers {{ ssh_server_ciphers | join(',') }}
+MACs {{ ssh_server_macs | join(',') }}
+KexAlgorithms {{ ssh_server_kexalgorithms | join(',') }}
 
 # Logging
 #SyslogFacility AUTH
-#LogLevel INFO
+LogLevel {{ ssh_server_loglevel | upper }}
 
-# Authentication:
-
-#LoginGraceTime 2m
-#PermitRootLogin prohibit-password
+# Authentication
+LoginGraceTime {{ ssh_server_logingracetime }}
+{% if ssh_server_permitrootlogin is boolean %}
+PermitRootLogin {{ ssh_server_permitrootlogin | ternary("yes", "no") }}
+{% else %}
+PermitRootLogin {{ ssh_server_permitrootlogin }}
+{% endif %}
+# Change to yes if you don't trust ~/.ssh/known_hosts for
 #StrictModes yes
-#MaxAuthTries 6
-#MaxSessions 10
+MaxAuthTries {{ ssh_server_maxauthtries }}
+MaxSessions {{ ssh_server_maxsessions }}
 
 #PubkeyAuthentication yes
 
@@ -45,16 +54,16 @@
 #AuthorizedKeysCommandUser nobody
 
 # For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
-#HostbasedAuthentication no
+HostbasedAuthentication {{ ssh_server_hostbasedauthentication | ternary("yes", "no") }}
 # Change to yes if you don't trust ~/.ssh/known_hosts for
 # HostbasedAuthentication
 #IgnoreUserKnownHosts no
 # Don't read the user's ~/.rhosts and ~/.shosts files
-#IgnoreRhosts yes
+IgnoreRhosts {{ ssh_server_ignorerhosts | ternary("yes", "no") }}
 
 # To disable tunneled clear text passwords, change to no here!
 PasswordAuthentication no
-#PermitEmptyPasswords no
+PermitEmptyPasswords {{ ssh_server_permitemptypasswords | ternary("yes", "no") }}
 
 # Change to yes to enable challenge-response passwords (beware issues with
 # some PAM modules and threads)
@@ -81,31 +90,30 @@ ChallengeResponseAuthentication no
 # If you just want the PAM account and session checks to run without
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
-UsePAM yes
+UsePAM {{ ssh_server_usepam | ternary("yes", "no") }}
 
 #AllowAgentForwarding yes
-#AllowTcpForwarding yes
+AllowTcpForwarding {{ ssh_server_allowtcpforwarding | ternary("yes", "no") }}
 #GatewayPorts no
-X11Forwarding yes
+X11Forwarding {{ ssh_server_x11forwarding | ternary("yes", "no") }}
 #X11DisplayOffset 10
 #X11UseLocalhost yes
 #PermitTTY yes
 PrintMotd no
 #PrintLastLog yes
 #TCPKeepAlive yes
-#PermitUserEnvironment no
+PermitUserEnvironment {{ ssh_server_permituserenvironment | ternary("yes", "no") }}
 #Compression delayed
-#ClientAliveInterval 0
-#ClientAliveCountMax 3
+ClientAliveInterval {{ ssh_server_clientaliveinterval }}
+ClientAliveCountMax {{ ssh_server_clientalivecountmax }}
 #UseDNS no
 #PidFile /var/run/sshd.pid
-#MaxStartups 10:30:100
+MaxStartups {{ ssh_server_maxstartups }}
 #PermitTunnel no
 #ChrootDirectory none
 #VersionAddendum none
 
-# no default banner path
-#Banner none
+Banner {{ ssh_server_banner }}
 
 # Allow client to pass locale environment variables
 AcceptEnv LANG LC_*
@@ -119,4 +127,17 @@ Subsystem	sftp	/usr/lib/openssh/sftp-server
 #	AllowTcpForwarding no
 #	PermitTTY no
 #	ForceCommand cvs server
-ClientAliveInterval 120
+#   ClientAliveInterval 120
+
+{% if ssh_server_denyusers %}
+DenyUsers {{ ssh_server_denyusers | join(' ') }}
+{% endif %}
+{% if ssh_server_allowusers %}
+AllowUsers {{ ssh_server_allowusers | join(' ') }}
+{% endif %}
+{% if ssh_server_denygroups %}
+DenyGroups {{ ssh_server_denygroups | join(' ') }}
+{% endif %}
+{% if ssh_server_allowgroups %}
+AllowGroups {{ ssh_server_allowgroups | join(' ') }}
+{% endif %}


### PR DESCRIPTION
Changes made:
* Define a default Protocol setting
* Manage the LogLevel of SSH server
* Manage X11Forwarding
* Manage MaxAuthTries
* Manage IgnoreRhosts
* Manage HostbasedAuthentication
* Manage PermitRootLogin
* Manage PermitEmptyPasswords
* Manage PermitUserEnvironment
* Manage Ciphers
* Manage MACs
* Manage KexAlgorithms
* Manage ClientAliveInterval
* Manage ClientAliveCountMax
* Manage LoginGraceTime
* Manage user and group access controls
* Manage Banner
* Manage UsePAM
* Manage AllowTcpForwarding
* Manage MaxStartups
* Manage MaxSessions