### PR TITLE
security: Update Ansible to >= 4.2.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-ansible = "< 4.2.0"
+ansible = ">= 4.2.0, < 4.3.0"
 ansible-base = ">= 2.10, < 2.11"
 ansible-lint = "*"
 docker = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9c5dad00c046a56cb84fdae666c71de7cde201ed03a39dc61af151480b63cf6f"
+            "sha256": "fd8b064d5b0808c74e60380de84b802cf93a0c2f7585b4a532d2372310ffc95a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -19,10 +19,10 @@
     "develop": {
         "ansible": {
             "hashes": [
-                "sha256:f561cca7fbc4daa14d98e18cd0cb74bd8b173f1501b8fa11543f6ef002de3167"
+                "sha256:737d819ffbd7a80c28795b4edd93e59ad21e6e6d53af0d19f57412814f9260d0"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "version": "==4.2.0"
         },
         "ansible-base": {
             "hashes": [


### PR DESCRIPTION
Addresses CVE-2021-3583.