### PR TITLE
ci: In Release job, change the checkout path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          path: 'stonesoupkitchen.ssh'
           fetch-depth: 0
 
       - name: Release


### PR DESCRIPTION
Paying for the sin of having a default working directory. This will
require some investigation as to how best to deduplicate it in the
future.